### PR TITLE
Update CircleCI binary cache to cache by architecture

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package.json" }}
+          - v1-dependencies-{{ arch }}-{{ checksum "package.json" }}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
@@ -32,7 +32,7 @@ jobs:
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+          key: v1-dependencies-{{ arch }}-{{ checksum "package.json" }}
 
       - persist_to_workspace:
           root: .


### PR DESCRIPTION
So that the build will not fail if trigger by different OS.
But really?! When will that happen. IDK CircleCI inform us to do
this so I do this. ¯\_(ツ)_/¯